### PR TITLE
java 11 y compatibilidad para web services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   <url>http://maven.apache.org</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <junit.version>4.13.2</junit.version>
     <log4j.version>1.2.17</log4j.version>
     <postgresql.version>42.7.2</postgresql.version>
@@ -42,53 +42,12 @@
       <version>${hibernate.version}</version>
     </dependency>
     
-    <!-- JAX-WS Dependencies for Java 21 -->
+    <!-- JAX-WS Dependencies for Java 11 -->
     <dependency>
       <groupId>com.sun.xml.ws</groupId>
       <artifactId>jaxws-rt</artifactId>
-      <version>4.0.0</version>
+      <version>2.3.3</version>
     </dependency>
-    
-    <!-- JAXB Dependencies for Java 21 -->
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.1</version>
-    </dependency>
-    
-    <!-- JAX-WS API -->
-    <!-- <dependency>
-      <groupId>javax.jws</groupId>
-      <artifactId>javax.jws-api</artifactId>
-      <version>1.1</version>
-    </dependency> -->
-    
-    <!-- Web Services Metadata -->
-    <!-- <dependency>
-      <groupId>javax.xml.ws</groupId>
-      <artifactId>jaxws-api</artifactId>
-      <version>2.3.1</version>
-    </dependency> -->
-    
-    <!-- Jakarta XML Web Services API -->
-    <dependency>
-      <groupId>jakarta.xml.ws</groupId>
-      <artifactId>jakarta.xml.ws-api</artifactId>
-      <version>4.0.0</version>
-    </dependency>
-    
-    <!-- Jakarta XML SOAP API -->
-    <dependency>
-      <groupId>jakarta.xml.soap</groupId>
-      <artifactId>jakarta.xml.soap-api</artifactId>
-      <version>3.0.0</version>
-    </dependency>
-    
     
   </dependencies>
   <build>
@@ -99,8 +58,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <source>21</source>
-          <target>21</target>
+          <source>11</source>
+          <target>11</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/src/main/java/publicadores/ArticuloEspecialPublicador.java
+++ b/src/main/java/publicadores/ArticuloEspecialPublicador.java
@@ -1,11 +1,11 @@
 package publicadores;
 
-import jakarta.jws.WebMethod;
-import jakarta.jws.WebService;
-import jakarta.jws.soap.SOAPBinding;
-import jakarta.jws.soap.SOAPBinding.ParameterStyle;
-import jakarta.jws.soap.SOAPBinding.Style;
-import jakarta.xml.ws.Endpoint;
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.jws.soap.SOAPBinding.ParameterStyle;
+import javax.jws.soap.SOAPBinding.Style;
+import javax.xml.ws.Endpoint;
 
 import configuraciones.WebServiceConfiguracion;
 import datatypes.DtArticuloEspecial;

--- a/src/main/java/publicadores/AutenticacionPublicador.java
+++ b/src/main/java/publicadores/AutenticacionPublicador.java
@@ -1,11 +1,11 @@
 package publicadores;
 
-import jakarta.jws.WebMethod;
-import jakarta.jws.WebService;
-import jakarta.jws.soap.SOAPBinding;
-import jakarta.jws.soap.SOAPBinding.ParameterStyle;
-import jakarta.jws.soap.SOAPBinding.Style;
-import jakarta.xml.ws.Endpoint;
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.jws.soap.SOAPBinding.ParameterStyle;
+import javax.jws.soap.SOAPBinding.Style;
+import javax.xml.ws.Endpoint;
 
 import configuraciones.WebServiceConfiguracion;
 import excepciones.LectorNoExisteException;

--- a/src/main/java/publicadores/BibliotecarioPublicador.java
+++ b/src/main/java/publicadores/BibliotecarioPublicador.java
@@ -1,11 +1,11 @@
 package publicadores;
 
-import jakarta.jws.WebMethod;
-import jakarta.jws.WebService;
-import jakarta.jws.soap.SOAPBinding;
-import jakarta.jws.soap.SOAPBinding.ParameterStyle;
-import jakarta.jws.soap.SOAPBinding.Style;
-import jakarta.xml.ws.Endpoint;
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.jws.soap.SOAPBinding.ParameterStyle;
+import javax.jws.soap.SOAPBinding.Style;
+import javax.xml.ws.Endpoint;
 
 import configuraciones.WebServiceConfiguracion;
 import datatypes.DtBibliotecario;

--- a/src/main/java/publicadores/LectorPublicador.java
+++ b/src/main/java/publicadores/LectorPublicador.java
@@ -1,11 +1,11 @@
 package publicadores;
 
-import jakarta.jws.WebMethod;
-import jakarta.jws.WebService;
-import jakarta.jws.soap.SOAPBinding;
-import jakarta.jws.soap.SOAPBinding.ParameterStyle;
-import jakarta.jws.soap.SOAPBinding.Style;
-import jakarta.xml.ws.Endpoint;
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.jws.soap.SOAPBinding.ParameterStyle;
+import javax.jws.soap.SOAPBinding.Style;
+import javax.xml.ws.Endpoint;
 
 import configuraciones.WebServiceConfiguracion;
 import datatypes.DtLector;

--- a/src/main/java/publicadores/LibroPublicador.java
+++ b/src/main/java/publicadores/LibroPublicador.java
@@ -1,11 +1,11 @@
 package publicadores;
 
-import jakarta.jws.WebMethod;
-import jakarta.jws.WebService;
-import jakarta.jws.soap.SOAPBinding;
-import jakarta.jws.soap.SOAPBinding.ParameterStyle;
-import jakarta.jws.soap.SOAPBinding.Style;
-import jakarta.xml.ws.Endpoint;
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.jws.soap.SOAPBinding.ParameterStyle;
+import javax.jws.soap.SOAPBinding.Style;
+import javax.xml.ws.Endpoint;
 
 import configuraciones.WebServiceConfiguracion;
 import datatypes.DtLibro;

--- a/src/main/java/publicadores/PrestamoPublicador.java
+++ b/src/main/java/publicadores/PrestamoPublicador.java
@@ -1,11 +1,11 @@
 package publicadores;
 
-import jakarta.jws.WebMethod;
-import jakarta.jws.WebService;
-import jakarta.jws.soap.SOAPBinding;
-import jakarta.jws.soap.SOAPBinding.ParameterStyle;
-import jakarta.jws.soap.SOAPBinding.Style;
-import jakarta.xml.ws.Endpoint;
+import javax.jws.WebMethod;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.jws.soap.SOAPBinding.ParameterStyle;
+import javax.jws.soap.SOAPBinding.Style;
+import javax.xml.ws.Endpoint;
 
 import configuraciones.WebServiceConfiguracion;
 import datatypes.DtPrestamo;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Targets Java 11 and replaces jakarta.* with javax.* JAX-WS across publishers, updating dependencies and compiler settings.
> 
> - **Build/Dependencies**:
>   - Set `maven-compiler-plugin` and properties to Java `11`.
>   - Use `com.sun.xml.ws:jaxws-rt:2.3.3`; remove Jakarta XML WS/SOAP APIs and extra JAXB deps.
> - **Web Service Publishers** (`src/main/java/publicadores/*Publicador.java`):
>   - Replace `jakarta.*` imports with `javax.*` (`WebService`, `WebMethod`, `SOAPBinding`, `Endpoint`) with no API changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00ac46fe8fc994f22a23204d62319477b4aaac5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->