### PR TITLE
migracion a hibernate 6x

### DIFF
--- a/ejecutar.bat
+++ b/ejecutar.bat
@@ -1,0 +1,15 @@
+@echo off
+echo ========================================
+echo  SISTEMA DE BIBLIOTECA - NUEVA VERSION
+echo ========================================
+echo.
+echo Iniciando aplicacion...
+echo.
+
+REM Configurar JAVA_HOME
+set JAVA_HOME=C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot
+
+REM Ejecutar la aplicacion
+java -cp "target/classes;target/dependency/*" MainNuevo
+
+pause

--- a/ejecutar.cmd
+++ b/ejecutar.cmd
@@ -1,0 +1,28 @@
+@echo off
+echo ========================================
+echo  SISTEMA DE BIBLIOTECA - NUEVA VERSION
+echo ========================================
+echo.
+echo Verificando configuracion...
+
+REM Configurar JAVA_HOME para Java 21
+set JAVA_HOME=C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot
+
+REM Verificar que Java esté disponible
+java -version
+if %errorlevel% neq 0 (
+    echo ERROR: Java no encontrado. Verifica que JAVA_HOME esté configurado correctamente.
+    pause
+    exit /b 1
+)
+
+echo.
+echo Iniciando aplicacion...
+echo.
+
+REM Ejecutar la aplicacion con todas las dependencias
+java -cp "target/classes;target/dependency/*" MainNuevo
+
+echo.
+echo Aplicacion finalizada.
+pause

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <junit.version>4.13.2</junit.version>
     <log4j.version>1.2.17</log4j.version>
     <postgresql.version>42.7.2</postgresql.version>
-    <hibernate.version>5.6.15.Final</hibernate.version>
+    <hibernate.version>6.4.2.Final</hibernate.version>
   </properties>
   <dependencies>
     <dependency>
@@ -37,9 +37,23 @@
     </dependency>
     <!-- Hibernate Core -->
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <version>${hibernate.version}</version>
+    </dependency>
+    
+    <!-- Jakarta Persistence API -->
+    <dependency>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    
+    <!-- Hibernate Validator para Jakarta -->
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>8.0.1.Final</version>
     </dependency>
     
     <!-- JAX-WS Dependencies for Java 21 -->

--- a/probar_migracion.cmd
+++ b/probar_migracion.cmd
@@ -1,0 +1,32 @@
+@echo off
+echo ========================================
+echo  PROBANDO MIGRACION HIBERNATE 6.x + JAKARTA
+echo ========================================
+echo.
+
+REM Configurar Java 21
+set JAVA_HOME=C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot
+set PATH=%JAVA_HOME%\bin;%PATH%
+
+echo Verificando Java...
+java -version
+echo.
+javac -version
+echo.
+
+echo Compilando proyecto...
+mvn clean compile
+
+if %errorlevel% equ 0 (
+    echo.
+    echo ✅ COMPILACION EXITOSA!
+    echo.
+    echo Probando ejecucion...
+    mvn exec:java -Dexec.mainClass="MainNuevo"
+) else (
+    echo.
+    echo ❌ ERROR EN COMPILACION
+    echo Revisa los errores arriba
+)
+
+pause

--- a/src/main/java/logica/ArticuloEspecial.java
+++ b/src/main/java/logica/ArticuloEspecial.java
@@ -1,8 +1,8 @@
 package logica;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
 import java.util.Date;
 
 /**
@@ -17,7 +17,7 @@ public class ArticuloEspecial extends Material {
     @Column(nullable = false, length = 500)
     private String descripcion;
     
-    @Column(nullable = false, precision = 10, scale = 3)
+    @Column(nullable = false)
     private Float pesoKg;
     
     @Column(nullable = false, length = 100)

--- a/src/main/java/logica/Bibliotecario.java
+++ b/src/main/java/logica/Bibliotecario.java
@@ -1,7 +1,7 @@
 package logica;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 /**
  * Entidad JPA que representa un bibliotecario en el sistema

--- a/src/main/java/logica/Lector.java
+++ b/src/main/java/logica/Lector.java
@@ -1,11 +1,11 @@
 package logica;
 
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import java.util.Date;
 
 /**

--- a/src/main/java/logica/Libro.java
+++ b/src/main/java/logica/Libro.java
@@ -1,8 +1,8 @@
 package logica;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
 import java.util.Date;
 
 /**

--- a/src/main/java/logica/Material.java
+++ b/src/main/java/logica/Material.java
@@ -1,12 +1,12 @@
 package logica;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import java.util.Date;
 import java.util.UUID;
 

--- a/src/main/java/logica/Prestamo.java
+++ b/src/main/java/logica/Prestamo.java
@@ -1,6 +1,6 @@
 package logica;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 /**

--- a/src/main/java/logica/Usuario.java
+++ b/src/main/java/logica/Usuario.java
@@ -1,11 +1,11 @@
 package logica;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.Table;
-import javax.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
 
 /**
  * Clase abstracta que representa un usuario base en el sistema

--- a/src/main/java/persistencia/Conexion.java
+++ b/src/main/java/persistencia/Conexion.java
@@ -1,8 +1,8 @@
 package persistencia;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 
 /**
  * Clase Singleton para manejar la conexión a la base de datos

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+<persistence version="3.0" xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
-             http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+             https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd">
 
     <persistence-unit name="biblioteca-persistence-unit" transaction-type="RESOURCE_LOCAL">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
@@ -14,13 +14,14 @@
         <class>logica.Material</class>
         <class>logica.ArticuloEspecial</class>
         <class>logica.Libro</class>
+        <class>logica.Prestamo</class>
         
         <properties>
             <!-- Configuración de PostgreSQL Database -->
-            <property name="javax.persistence.jdbc.driver" value="org.postgresql.Driver"/>
-            <property name="javax.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/biblioteca_bd"/>
-            <property name="javax.persistence.jdbc.user" value="admin"/>
-            <property name="javax.persistence.jdbc.password" value="admin"/>
+            <property name="jakarta.persistence.jdbc.driver" value="org.postgresql.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:postgresql://localhost:5434/biblioteca_bd"/>
+            <property name="jakarta.persistence.jdbc.user" value="admin"/>
+            <property name="jakarta.persistence.jdbc.password" value="admin"/>
             
             <!-- Configuración de Hibernate -->
             <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>


### PR DESCRIPTION
🚀 Migración a Hibernate 6.x + Jakarta Persistence

Resumen
Migración completa del backend de Hibernate 5.6.15 a 6.4.2 con Jakarta Persistence para resolver conflictos de compatibilidad con Java 21 y Web Services.
Cambios Principales
📦 Dependencias
hibernate-core: 5.6.15.Final → 6.4.2.Final
groupId: org.hibernate → org.hibernate.orm
Agregado: jakarta.persistence-api 3.1.0
Agregado: hibernate-validator 8.0.1.Final
🔄 Migración de APIs
javax.persistence.* → jakarta.persistence.* en todas las entidades
persistence.xml: versión 2.1 → 3.0, namespace Jakarta
Propiedades: javax.persistence.* → jakarta.persistence.*

🏗️ Entidades Actualizadas
Usuario, Material, Bibliotecario, Lector, Libro, ArticuloEspecial, Prestamo
Conexion (persistencia)
Corregido mapeo @Column para compatibilidad con Hibernate 6
⚙️ Configuración
URL BD corregida: puerto 5434 (Docker)
Agregada entidad Prestamo faltante en persistence.xml
Beneficios
✅ Compatibilidad total con Java 21
✅ Eliminación de conflictos Jakarta vs javax
✅ Mejor rendimiento y características de Hibernate 6.x
✅ Futuro-proof para nuevas versiones de Java
Testing
✅ Compilación exitosa sin errores
✅ Conexión a base de datos funcional
✅ Web Services operativos